### PR TITLE
ci: add CI + Cloudflare Pages deploy workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check PR has linked issue
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            PR_NUMBER=$(echo $GITHUB_REF | sed "s|refs/pull/\([0-9]*\)/merge|\1|")
+            LINKED_ISSUE=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER --jq ".body" | grep -oE "#[0-9]+" | head -1)
+            if [ -z "$LINKED_ISSUE" ]; then
+              echo "❌ PR must link to an issue (e.g., closes #123)"
+              exit 1
+            fi
+            echo "✅ Linked issue found: $LINKED_ISSUE"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Hello world
+        run: echo "CI passed!"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,17 +12,25 @@ jobs:
       contents: read
       deployments: write
 
-    # Avoid failing every push if secrets are not configured.
-    if: ${{ secrets.CF_API_TOKEN != '' && secrets.CF_ACCOUNT_ID != '' }}
+    env:
+      CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+      CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Deploy skipped (missing Cloudflare secrets)
+        if: ${{ env.CF_API_TOKEN == '' || env.CF_ACCOUNT_ID == '' }}
+        run: |
+          echo "Cloudflare Pages deploy is skipped."
+          echo "Missing secrets: CF_API_TOKEN and/or CF_ACCOUNT_ID"
+
       - name: Deploy to Cloudflare Pages
+        if: ${{ env.CF_API_TOKEN != '' && env.CF_ACCOUNT_ID != '' }}
         uses: cloudflare/pages-action@v1
         with:
-          apiToken: ${{ secrets.CF_API_TOKEN }}
-          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          apiToken: ${{ env.CF_API_TOKEN }}
+          accountId: ${{ env.CF_ACCOUNT_ID }}
           projectName: ${{ vars.CF_PAGES_PROJECT || github.event.repository.name }}
           directory: ${{ vars.CF_PAGES_DIR || '.' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy to Cloudflare Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+
+    # Avoid failing every push if secrets are not configured.
+    if: ${{ secrets.CF_API_TOKEN != '' && secrets.CF_ACCOUNT_ID != '' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          projectName: ${{ vars.CF_PAGES_PROJECT || github.event.repository.name }}
+          directory: ${{ vars.CF_PAGES_DIR || '.' }}


### PR DESCRIPTION
Copied CI/CD workflow patterns from https://github.com/monthop-gmail/opencode-line-playground-template-000

Adds:
- .github/workflows/ci.yml (requires PRs to link an issue)
- .github/workflows/deploy.yml (Cloudflare Pages deploy on push to main)

Required secrets:
- CF_API_TOKEN
- CF_ACCOUNT_ID

Optional repo variables:
- CF_PAGES_PROJECT (default: repo name)
- CF_PAGES_DIR (default: .)

Closes #2